### PR TITLE
Use 'slice' for arguments to array converting

### DIFF
--- a/angular-class-test.coffee
+++ b/angular-class-test.coffee
@@ -30,6 +30,12 @@ describe 'AngularClass.factory', ->
   it 'should return callback that sets dependecies 2', ->
     expect(Helper.factory()[2](null, 'MODULE')._DEP2).toEqual('MODULE')
 
+  it 'should inject array as dependency 1 properly', ->
+    expect(Helper.factory()[2]([1, 2, 3])._DEP1).toEqual([1, 2, 3])
+
+  it 'should inject array as dependency 2 properly', ->
+    expect(Helper.factory()[2](null, [1, 2, 3])._DEP2).toEqual([1, 2, 3])
+
   it 'should return instance of Helper', ->
     expect(Helper.factory()[2]() instanceof Helper).toEqual(true)
 

--- a/angular-class.coffee
+++ b/angular-class.coffee
@@ -37,7 +37,7 @@ class @IdFly.AngularClass
     imports = this._import || []
 
     factory = () =>
-      args = Array.prototype.concat.apply([], arguments)
+      args = Array.prototype.slice.call(arguments)
 
       result = resultCallback()
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-class-coffee",
   "description": "coffeescript classes support for angular",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": false,
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Hi,
There is a problem with converting arguments before injecting to controller: if there is an array in the arguments, it will be flattened. The `concat` call is a culprit.

Here is a simple check:
```
foo = function () { return Array.prototype.concat.apply([], arguments) }
foo(1, 2, 3, [4, 5])
> [1, 2, 3, 4, 5]
bar = function () { return Array.prototype.slice.call(arguments) }
bar(1, 2, 3, [4, 5])
> [1, 2, 3, [4,5]]
```

So I suggest use of `slice`, as proposed here - https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Functions/arguments